### PR TITLE
Changing the master and slave terminology

### DIFF
--- a/src/connectToMySQL.py
+++ b/src/connectToMySQL.py
@@ -2,7 +2,7 @@ from pyspark.sql import SparkSession
 
 if __name__ == '__main__' :
     spark = SparkSession.builder \
-        .master("local") \
+        .main("local") \
         .appName("Word Count") \
         .getOrCreate()
 


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.